### PR TITLE
Fix LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,3 @@
-MIT License
+Versions of Scratch prior to 2.0 are licensed under the [Scratch Source Code License](https://en.scratch-wiki.info/wiki/Scratch_Source_Code_License).
 
-Copyright (c) 2020 retro-person
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Scratch 2.0 is licensed under the [GNU General Public License version 2](https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).


### PR DESCRIPTION
Scratch is developed by MIT, but it does not use that license.

I can guarentee that even forks use one of the licenses, for the following reasons:

* GPLv2: Copyleft, so forks have GPLv2. Scratch 2.0.
* SSCL: Has some limitations regarding the Scratch trademark and derivative works uploading to scratch.mit.edu. I doubt any other license would have these features, so Scratch <=1.4 forks should have the SSCL.